### PR TITLE
feat: make database connection generic

### DIFF
--- a/dev/.env-dev
+++ b/dev/.env-dev
@@ -8,12 +8,8 @@ LOG_LEVEL=DEBUG
 OPENID_CONNECT_DISCOVERY_URL=http://localhost:8080/auth/realms/tdp_server_dev/.well-known/openid-configuration
 OPENID_CLIENT_ID=tdp_server_id
 
-# Postgres
-POSTGRES_SERVER=localhost:5432
-POSTGRES_USER=tdp_user
-POSTGRES_PASSWORD=tdp_password
-POSTGRES_DB=tdp_dev_db
-POSTGRES_SCHEMA=tdp
+# Database 
+DATABASE_DSN=postgresql://tdp_user:tdp_password@localhost/tdp_dev_db
 
 # TDP
 TDP_COLLECTION_PATH=<collection path>

--- a/dev/init_script.sql
+++ b/dev/init_script.sql
@@ -1,3 +1,5 @@
 CREATE DATABASE keycloak;
 -- default database is tdp_dev_db
 CREATE SCHEMA tdp;
+-- set default schema for tdp user
+ALTER ROLE tdp_user SET search_path TO tdp,public;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ fastapi = { version = "0.75.0" }
 tdp-lib = { git = "https://github.com/TOSIT-IO/tdp-lib" }
 alembic = "1.7.7"
 tenacity = "8.0.1"
-psycopg2 = "2.9.3"
+psycopg2 = { version ="2.9.3", optional = true}
 Authlib = "1.0.0"
 httpx = "0.22.0"
 python-jose = { version = "3.3.0", extras = ["cryptography"] }
@@ -22,6 +22,9 @@ black = "21.12b0"
 isort = "4.3.21"
 poetry-githooks = "2.0.0"
 uvicorn = { version = "0.15.0", extras = ["standard"] }
+
+[tool.poetry.extras]
+pg = ["psycopg2"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tdp_server/alembic/env.py
+++ b/tdp_server/alembic/env.py
@@ -38,7 +38,7 @@ def get_url():
     # server = Settings.POSTGRES_SERVER
     # db = Settings.POSTGRES_DB
     # return f"postgresql://{user}:{password}@{server}/{db}"
-    return settings.SQLALCHEMY_DATABASE_URI
+    return settings.DATABASE_DSN
 
 
 def run_migrations_offline():

--- a/tdp_server/core/config.py
+++ b/tdp_server/core/config.py
@@ -2,7 +2,7 @@ import logging
 import os
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import AnyHttpUrl, BaseSettings, DirectoryPath, PostgresDsn, validator
+from pydantic import AnyHttpUrl, BaseSettings, DirectoryPath, validator
 from tdp.core.collection import Collection
 from tdp.core.collections import Collections
 
@@ -33,24 +33,7 @@ class Settings(BaseSettings):
 
     PROJECT_NAME: str
 
-    POSTGRES_SERVER: str
-    POSTGRES_USER: str
-    POSTGRES_PASSWORD: str
-    POSTGRES_DB: str
-    POSTGRES_SCHEMA: str = "tdp"
-    SQLALCHEMY_DATABASE_URI: Optional[PostgresDsn] = None
-
-    @validator("SQLALCHEMY_DATABASE_URI", pre=True)
-    def assemble_db_connection(cls, v: Optional[str], values: Dict[str, Any]) -> Any:
-        if isinstance(v, str):
-            return v
-        return PostgresDsn.build(
-            scheme="postgresql",
-            user=values.get("POSTGRES_USER"),
-            password=values.get("POSTGRES_PASSWORD"),
-            host=values.get("POSTGRES_SERVER"),
-            path=f"/{values.get('POSTGRES_DB') or ''}",
-        )
+    DATABASE_DSN: str
 
     LOG_LEVEL: str = "INFO"
 

--- a/tdp_server/db/session.py
+++ b/tdp_server/db/session.py
@@ -3,10 +3,6 @@ from sqlalchemy.orm import sessionmaker
 
 from tdp_server.core.config import settings
 
-engine = create_engine(
-    settings.SQLALCHEMY_DATABASE_URI,  # type: ignore
-    pool_pre_ping=True,
-    connect_args={"options": f"-csearch_path={settings.POSTGRES_SCHEMA}"},
-)
+engine = create_engine(settings.DATABASE_DSN, pool_pre_ping=True)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
fix #31 

This PR makes the database connection generic, what's changed:
- Add an extra `pg` to the project definition, to get the recommended postgresql driver
- Connection configuration is now the key `DATABASE_DSN`
- No meddling with schema in the code. If you want a different schema for your user in Postgres, do it on administrator side. (Here, it's done in the `init_script.sql` file)