### PR TITLE
fix: set selinux private unshared volume option

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "5432:5432"
     volumes:
       - db-data:/var/lib/postgresql/data
-      - ./init_script.sql:/docker-entrypoint-initdb.d/init_script.sql
+      - ./init_script.sql:/docker-entrypoint-initdb.d/init_script.sql:Z
 
   pgadmin:
     container_name: pgadmin4_container
@@ -52,7 +52,7 @@ services:
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: Pa55w0rd
     volumes:
-      - ./configure-keycloak.sh:/entrypoint.sh
+      - ./configure-keycloak.sh:/entrypoint.sh:Z
     depends_on:
       - keycloak
 


### PR DESCRIPTION
When running this docker-compose stack in a SELinux confined environment, we need to tell the container engine to properly set the SELinux labels on the files.

To tell docker (or podman), to setup selinux labels on the file, there are 2 options:
- `z`: shared (between multiple containers) label `system_u:object_r:container_file_t:s0`
- `Z`: private, unshared label `system_u:object_r:container_file_t:s0:c296,c736`