### PR TITLE
fix: add tilde expantion to path validation

### DIFF
--- a/tdp_server/core/config.py
+++ b/tdp_server/core/config.py
@@ -2,9 +2,11 @@ import logging
 import os
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import AnyHttpUrl, BaseSettings, DirectoryPath, validator
+from pydantic import AnyHttpUrl, BaseSettings, validator
 from tdp.core.collection import Collection
 from tdp.core.collections import Collections
+
+from tdp_server.core.validator_types import ExistingDir
 
 
 class Settings(BaseSettings):
@@ -45,8 +47,8 @@ class Settings(BaseSettings):
         raise ValueError(v)
 
     TDP_COLLECTION_PATH: str
-    TDP_RUN_DIRECTORY: DirectoryPath
-    TDP_VARS: DirectoryPath
+    TDP_RUN_DIRECTORY: ExistingDir
+    TDP_VARS: ExistingDir
 
     TDP_COLLECTIONS: Collections = Collections({})
 

--- a/tdp_server/core/validator_types.py
+++ b/tdp_server/core/validator_types.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from typing import Any, Dict
+
+from pydantic import DirectoryPath
+
+
+class ExistingDir(DirectoryPath):
+    @classmethod
+    def __get_validators__(cls) -> "CallableGenerator":  # type: ignore
+        yield cls.validate_expanduser
+        yield from DirectoryPath.__get_validators__()  # type: ignore
+
+    @classmethod
+    def validate_expanduser(cls, value: Path) -> Path:
+        return Path(value).expanduser().resolve()


### PR DESCRIPTION
fix #45

pydantic validation model `DirectoryPath` does not expand user home directory.