### PR TITLE
fix: initialize_database does not depends on current directory

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = tdp_server/alembic
+script_location = %(here)s/tdp_server/alembic
 
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s

--- a/tdp_server/initialize_database.py
+++ b/tdp_server/initialize_database.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from tdp.core import models as tdp_models
 
 from alembic import command
@@ -9,5 +11,5 @@ from tdp_server.db.session import engine
 
 Base.metadata.create_all(engine)
 
-alembic_cfg = Config("alembic.ini")
+alembic_cfg = Config(str(Path(__file__).parent / ".." / "alembic.ini"))
 command.stamp(alembic_cfg, "head")


### PR DESCRIPTION
initialize_database script find the alembic.ini relative to the initialize_database location in order to not depends on current directory.

<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #109

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->



#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
