### PR TITLE
106 reconfigure action cant be logged in the db

### DIFF
--- a/tdp_server/pre_start.py
+++ b/tdp_server/pre_start.py
@@ -29,6 +29,8 @@ def init() -> None:
     except Exception as e:
         logger.error(e)
         raise e
+    finally:
+        db.close()
 
 
 def main() -> None:

--- a/tdp_server/services/deployment_crud.py
+++ b/tdp_server/services/deployment_crud.py
@@ -23,6 +23,7 @@ class DeploymentCrud:
             .offset(offset)
         )
         query_result = db.execute(query).unique().scalars().fetchall()
+        db.close()
 
         return [
             parse_deployment_log(deployment_log, DeploymentLog)
@@ -40,6 +41,8 @@ class DeploymentCrud:
             deployment_log = db.execute(query).scalar_one()
         except NoResultFound:
             raise ValueError("Invalid deployment id")
+        finally:
+            db.close()
         deployment_schema = parse_deployment_log(
             deployment_log, DeploymentLogWithOperations
         )
@@ -58,5 +61,7 @@ class DeploymentCrud:
             operation_log = db.execute(query).scalar_one()
         except NoResultFound:
             raise ValueError("Invalid deployment id or operation name")
+        finally:
+            db.close()
 
         return OperationLog.from_orm(operation_log)

--- a/tdp_server/services/deployment_crud.py
+++ b/tdp_server/services/deployment_crud.py
@@ -23,7 +23,6 @@ class DeploymentCrud:
             .offset(offset)
         )
         query_result = db.execute(query).unique().scalars().fetchall()
-        db.close()
 
         return [
             parse_deployment_log(deployment_log, DeploymentLog)
@@ -41,8 +40,6 @@ class DeploymentCrud:
             deployment_log = db.execute(query).scalar_one()
         except NoResultFound:
             raise ValueError("Invalid deployment id")
-        finally:
-            db.close()
         deployment_schema = parse_deployment_log(
             deployment_log, DeploymentLogWithOperations
         )
@@ -61,7 +58,5 @@ class DeploymentCrud:
             operation_log = db.execute(query).scalar_one()
         except NoResultFound:
             raise ValueError("Invalid deployment id or operation name")
-        finally:
-            db.close()
 
         return OperationLog.from_orm(operation_log)

--- a/tdp_server/services/deployment_plan.py
+++ b/tdp_server/services/deployment_plan.py
@@ -87,6 +87,7 @@ class DeploymentPlanService:
         latest_successes = db.execute(
             get_latest_success_service_component_version_query()
         ).all()
+        db.close()
         try:
             return await AsyncDeploymentPlan.from_reconfigure(
                 dag, cluster_variables, latest_successes
@@ -103,6 +104,7 @@ class DeploymentPlanService:
             .unique()
             .scalar_one_or_none()
         )
+        db.close()
         if deployment_log is None:
             if resume_request.id is None:
                 raise ValueError("No deployments yet")


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Please make sure:
1. Your PR fixes a referenced issue, please create one if no issue applies to your PR.
2. The issue number is referenced in the branch name.
3. You follow the contributing rules at: https://github.com/TOSIT-IO/tdp-collection/blob/master/docs/contributing.md.
-->

#### Which issue(s) this PR fixes

<!-- Example: "Fixes #(issue number)" or "Fixes (link of issue)". -->

Fixes #106 

#### Additional comments

<!-- Example: "I was not sure if it is the right way to do but..." -->

This fix was tested with a SQLite database and a PostgreSQL, although this bug only appears with SQLite DB, and with the /reconfigure and /resume endpoints.
The other endpoints don't need the DB connection to be closed : if I add that, a sqlalchemy.orm.exc.DetachedInstanceError is raised :
>sqlalchemy.orm.exc.DetachedInstanceError: Parent instance <DeploymentLog at 0x7feb034b5760> is not bound to a Session; lazy load operation of attribute 'operations' cannot proceed (Background on this error at: https://sqlalche.me/e/14/bhk3)

#### Agreements

<!-- To make clear that you license your contribution under the Apache License Version 2.0, January 2004 (http://www.apache.org/licenses/LICENSE-2.0) and that you give permission to TOSIT (https://www.tosit.io/), you have to acknowledge this by using the following check-box. -->

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).
- [X] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.
